### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Available machines are:
 - openvario-7-CH070
 - openvario-57-lvds
 - openvario-43-rgb
+- openvario-7-AMPI
 
 ### Starting the build
 


### PR DESCRIPTION
Added new machine for 7" display Ampire, type AM-1280800P3TZQW-00H-AMPI, resolution: 1280x800, Brightness: 1500 cd/m2, LVDS interface, 24-bit color depth